### PR TITLE
Pool Server P2P Data Race

### DIFF
--- a/p2pv2/tcp_msg_handler.go
+++ b/p2pv2/tcp_msg_handler.go
@@ -14,7 +14,9 @@ func (p *P2P) handleConnMsg(connid uint64, conn net.Conn, peer *Peer, msg []byte
 	// fmt.Println("- - - - p2p.handleConnMsg", conn.RemoteAddr().String(), ":", msg)
 
 	ct := time.Now()
+	p.PeerChangeMux.Lock()
 	peer.activeTime = &ct // 活跃时间
+	p.PeerChangeMux.Unlock()
 
 	// 处理消息
 	msgty := msg[0]


### PR DESCRIPTION
In [node/p2pv2/tcp_msg_handler.go:17]
Added [p.PeerChangeMux.Lock() / p.PeerChangeMux.Unlock()]

+ Data Race # 19:
  Read at 0x00c42020c2b8 by goroutine 45:
    node/p2pv2.(*P2P).loop.func1()
      node/p2pv2/loop.go:59 +0x7c
    sync.(*Map).Range()
      /opt/go/go1_10_8/src/sync/map.go:337 +0x13b
    node/p2pv2.(*P2P).loop()
      node/p2pv2/loop.go:55 +0x418

  Previous write at 0x00c42020c2b8 by goroutine 142:
    node/p2pv2.(*P2P).handleConnMsg()
      node/p2pv2/tcp_msg_handler.go:17 +0x109