### PR TITLE
Pool Server P2P Data Race

### DIFF
--- a/p2pv2/loop.go
+++ b/p2pv2/loop.go
@@ -56,9 +56,11 @@ func (p *P2P) loop() {
 				peer := value.(*Peer)
 				if peer != nil {
 					// 超过5分钟没有活跃的节点
+					p.PeerChangeMux.RLock()
 					if peer.activeTime.Add(time.Minute * 5).Before(ct) {
 						sendTcpMsg(peer.conn, P2PMsgTypePing, nil) // send ping
 					}
+					p.PeerChangeMux.RUnlock()
 				}
 				return true
 			})


### PR DESCRIPTION
In [node/p2pv2/loop.go:59]
Added [p.PeerChangeMux.RLock() / p.PeerChangeMux.RUnlock()]

+ Data Race # 19:
  Read at 0x00c42020c2b8 by goroutine 45:
    node/p2pv2.(*P2P).loop.func1()
      node/p2pv2/loop.go:59 +0x7c
    sync.(*Map).Range()
      /opt/go/go1_10_8/src/sync/map.go:337 +0x13b
    node/p2pv2.(*P2P).loop()
      node/p2pv2/loop.go:55 +0x418

  Previous write at 0x00c42020c2b8 by goroutine 142:
    node/p2pv2.(*P2P).handleConnMsg()
      node/p2pv2/tcp_msg_handler.go:17 +0x109